### PR TITLE
Rename imagePickerController(_:didDeselectImageAsset:)

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Pickle (1.0.0)
+  - Pickle (1.1.0)
   - SwiftLint (0.18.1)
 
 DEPENDENCIES:
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Pickle: c9b9e1ddd4c9baaef4d3561ecbe99d71de35fbb6
+  Pickle: 1482e432a75aa9454d254916765f6079668e51c1
   SwiftLint: b467d08f5b25dc3b3cfed243d8e1b74b91714c67
 
 PODFILE CHECKSUM: deb6efd06d1eb162719911e286f38d05b1590fdb

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ else
 	ruby -pi -e "gsub(/:\s\d+\.\d+\.\d+/i, \": "$(version)"\")" .jazzy.yml
 	cd Example && xcrun agvtool new-marketing-version $(version)
 	xcrun agvtool new-marketing-version $(version)
+	bundle exec pod install --project-directory=Example
 endif
 
 carthage:

--- a/Pickle/Classes/ImagePickerConfigurable.swift
+++ b/Pickle/Classes/ImagePickerConfigurable.swift
@@ -13,7 +13,7 @@ import UIKit
 /// The ImagePickerConfigurable protocol defines the customizable properties of ImagePickerController.
 public protocol ImagePickerConfigurable {
 
-    // MARK: - UINavigationItem
+    // MARK: - Navigation Item
 
     /// A custom bar button item displayed on the left (or leading) edge of the navigation bar when the receiver is the top navigation item.
     var cancelBarButtonItem: UIBarButtonItem? { get }

--- a/Pickle/Classes/ImagePickerConfigurable.swift
+++ b/Pickle/Classes/ImagePickerConfigurable.swift
@@ -71,7 +71,7 @@ public protocol ImagePickerConfigurable {
     /// Specifies the number of photo selections is allowed in ImagePickerController.
     var allowedSelections: ImagePickerSelection? { get }
 
-    // MARK: -
+    // MARK: - Hint Label
 
     /// The margin for the text of the hint label.
     var hintTextMargin: UIEdgeInsets? { get }
@@ -81,9 +81,9 @@ public protocol ImagePickerConfigurable {
 /// An enum that represents photo selections allowed in ImagePickerController.
 public enum ImagePickerSelection {
 
-    // Unlimited number of selections.
+    /// Unlimited number of selections.
     case unlimited
 
-    // Limited selections with an associated number.
+    /// Limited selections with an associated number.
     case limit(to: Int)
 }

--- a/Pickle/Classes/ImagePickerController.swift
+++ b/Pickle/Classes/ImagePickerController.swift
@@ -291,7 +291,7 @@ extension ImagePickerController: PhotoGalleryViewControllerDelegate {
     internal func photoGalleryViewController(_ controller: PhotoGalleryViewController, didTogglePhoto asset: PHAsset) {
         if let selectedIndex = selectedAssets.index(of: asset) {
             selectedAssets.remove(at: selectedIndex)
-            imagePickerDelegate?.imagePickerController?(self, didUnselectImageAsset: asset)
+            imagePickerDelegate?.imagePickerController?(self, didDeselectImageAsset: asset)
         } else {
             switch allowedSelections {
             case .limit(to: let number) where 1 < number && selectedAssets.count < number:

--- a/Pickle/Classes/ImagePickerController.swift
+++ b/Pickle/Classes/ImagePickerController.swift
@@ -8,10 +8,12 @@
 //  See https://github.com/carousell/pickle/graphs/contributors for the list of project authors
 //
 
+// swiftlint:disable file_length
+
 import UIKit
 import Photos
 
-// swiftlint:disable file_length
+/// Carousell flavoured image picker with multiple photo selections.
 @objc
 open class ImagePickerController: UINavigationController {
 
@@ -210,10 +212,9 @@ open class ImagePickerController: UINavigationController {
 }
 
 
-// MARK: - UIImagePickerControllerDelegate
-
-
 extension ImagePickerController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+
+    // MARK: - UIImagePickerControllerDelegate
 
     public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
         defer {

--- a/Pickle/Classes/ImagePickerControllerDelegate.swift
+++ b/Pickle/Classes/ImagePickerControllerDelegate.swift
@@ -31,9 +31,9 @@ public protocol ImagePickerControllerDelegate: UINavigationControllerDelegate {
     /// Optional. Asks the delegate for the transitioning delegate for presenting the album list. The default transition is used if not implemented.
     @objc optional func imagePickerController(_ picker: ImagePickerController, transitioningDelegateForPresentingAlbumsViewController controller: UIViewController) -> UIViewControllerTransitioningDelegate
 
-    /// Optional. Tells the delegate that the user seleced an image asset.
+    /// Optional. Tells the delegate that the user selected an image asset.
     @objc optional func imagePickerController(_ picker: ImagePickerController, didSelectImageAsset asset: PHAsset)
 
-    /// Optional. Tells the delegate that the user unseleced an image asset.
-    @objc optional func imagePickerController(_ picker: ImagePickerController, didUnselectImageAsset asset: PHAsset)
+    /// Optional. Tells the delegate that the user deselected an image asset.
+    @objc optional func imagePickerController(_ picker: ImagePickerController, didDeselectImageAsset asset: PHAsset)
 }

--- a/Pickle/Classes/PhotoAlbumsTableView.swift
+++ b/Pickle/Classes/PhotoAlbumsTableView.swift
@@ -14,7 +14,7 @@ internal final class PhotoAlbumsTableView: UITableView {
 
     // MARK: - Initialization
 
-    convenience init(configuration: ImagePickerConfigurable? = nil) {
+    internal convenience init(configuration: ImagePickerConfigurable? = nil) {
         self.init(frame: .zero, style: .plain)
 
         let color = configuration?.photoAlbumsNavigationBarShadowColor


### PR DESCRIPTION
- [x] Rename `unselect` to `deselect` to follow the UIKit naming
- [x] Fix the format of `///` documentation comments
- [x] Fix the `make bump` script to update the spec checksum in Podfile