### PR TITLE
Automatically Update Docs from Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ xcuserdata/
 *.moved-aside
 *.xcuserstate
 *.bak
+*.pkg
 docs
 
 ## Obj-C/Swift specific

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ before_install:
 install:
   - bundle install --jobs=3 --retry=3 --deployment
   - bundle exec pod install --project-directory=Example
+  - sh scripts/install-carthage.sh 0.27.0
 before_script:
-  - if [ -n "$DANGER_GITHUB_API_TOKEN" ]; then bundle exec danger; else echo "Missing DANGER_GITHUB_API_TOKEN"; fi
+  - if [ -n "$DANGER_GITHUB_API_TOKEN" ]; then bundle exec danger; fi
 script:
   - make -B test
   - make -B carthage

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ script:
   - make -B test
   - make -B carthage
   - make -B docs
+after_success:
+  - sh scripts/update-docs.sh
 notifications:
   email: false
   slack:

--- a/scripts/install-carthage.sh
+++ b/scripts/install-carthage.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 VERSION_NUMBER"
+  exit 1
+fi
+
+VERSION=$(carthage version)
+
+if [[ $1 = "$VERSION" ]]; then
+	echo "Using carthage $1"
+	exit 0
+fi
+
+echo "$VERSION"
+curl -OL "https://github.com/Carthage/Carthage/releases/download/$1/Carthage.pkg"
+sudo installer -pkg Carthage.pkg -target /
+rm Carthage.pkg
+carthage version

--- a/scripts/update-docs.sh
+++ b/scripts/update-docs.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+cd docs && pwd
+
+if [[ "${TRAVIS_COMMIT_MESSAGE}" = Merge\ pull\ request* ]] && [[ -n "${DANGER_GITHUB_API_TOKEN}" ]]; then
+  echo "Updating gh-pages"
+  git remote add upstream "https://${GH_PAGES_GITHUB_API_TOKEN}@github.com/carousell/pickle.git"
+  git push --quiet upstream HEAD:gh-pages
+  git remote remove upstream
+else
+  echo "Skip gh-pages updates for the commit:"
+  echo "\n    ${TRAVIS_COMMIT_MESSAGE}\n"
+fi
+
+cd -


### PR DESCRIPTION
Add a script to CI `after_success` that pushes the generated docs to the `gh-pages` branch when the commit message starts with **Merge pull request**.