### PR TITLE
Fix Docs Update Script

### DIFF
--- a/scripts/update-docs.sh
+++ b/scripts/update-docs.sh
@@ -2,7 +2,7 @@
 
 cd docs && pwd
 
-if [[ "${TRAVIS_COMMIT_MESSAGE}" = Merge\ pull\ request* ]] && [[ -n "${DANGER_GITHUB_API_TOKEN}" ]]; then
+if [[ "${TRAVIS_COMMIT_MESSAGE}" = Merge* ]] && [[ -n "${GH_PAGES_GITHUB_API_TOKEN}" ]]; then
   echo "Updating gh-pages"
   git remote add upstream "https://${GH_PAGES_GITHUB_API_TOKEN}@github.com/carousell/pickle.git"
   git push --quiet upstream HEAD:gh-pages


### PR DESCRIPTION
Fix the wrong ENV variable in the script. It should be `GH_PAGES_GITHUB_API_TOKEN` instead of `DANGER_GITHUB_API_TOKEN`.