### PR TITLE
Release 1.3.1

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -5,6 +5,6 @@ github_url: https://github.com/carousell/pickle
 github_file_prefix: https://github.com/carousell/pickle/blob/master
 xcodebuild_arguments: [-project, Example/Pods/Pods.xcodeproj, -scheme, Pickle]
 module: Pickle
-module_version: 1.3.0
+module_version: 1.3.1
 output: docs/output
 theme: fullwidth

--- a/Example/Pickle/Info.plist
+++ b/Example/Pickle/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Pickle (1.3.0)
+  - Pickle (1.3.1)
   - SwiftLint (0.27.0)
 
 DEPENDENCIES:
@@ -13,7 +13,7 @@ EXTERNAL SOURCES:
     :podspec: https://raw.githubusercontent.com/CocoaPods/Specs/master/Specs/4/0/1/SwiftLint/0.27.0/SwiftLint.podspec.json
 
 SPEC CHECKSUMS:
-  Pickle: ac29bdd7b53f14dec1c75b7c9f35a8c1657b6b0a
+  Pickle: 63e33e08fcb1490b9b932bcdb50c12ecdc3cecc2
   SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
 
 PODFILE CHECKSUM: 876096377525bec4eeb5dc771e7fdfbcdcb46898

--- a/Example/Pods/Target Support Files/Pickle/Info.plist
+++ b/Example/Pods/Target Support Files/Pickle/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.3.0</string>
+  <string>1.3.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/UITests/Info.plist
+++ b/Example/UITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Pickle.podspec
+++ b/Pickle.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Pickle'
-  s.version          = '1.3.0'
+  s.version          = '1.3.1'
   s.summary          = 'Carousell flavoured image picker with multiple photo selections.'
   s.homepage         = 'https://github.com/carousell/pickle'
   s.license          = { :type => 'Apache License 2.0', :file => 'LICENSE' }


### PR DESCRIPTION
`master` is the protected branch so I can't directly push the changes. This pull request is just for bumping the version number.

Release 1.3.1 includes the `swift_version` specification in the podspec, which will allow the library to be used with projects in Swift 4.2.