### PR TITLE
Use full screen model presentation style

### DIFF
--- a/Pickle/Classes/ImagePickerController.swift
+++ b/Pickle/Classes/ImagePickerController.swift
@@ -85,6 +85,9 @@ open class ImagePickerController: UINavigationController {
             camera.delegate = self
             return camera
         }
+
+        // The UI design doesn't work well with iOS 13 default sheet modal presentation.
+        modalPresentationStyle = .fullScreen
     }
 
     /// Returns an object initialized from data in a given unarchiver.


### PR DESCRIPTION
The `PhotoAlbumsViewController` doesn't work well with iOS 13 default sheet modal presentation so setting the presentation style to `.fullScreen` should avoid the issue.